### PR TITLE
Avoid matching the entire URL

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,8 +6,8 @@ export const patternValidationRegex = /^(https?|wss?|file|ftp|\*):\/\/(\*|\*\.[^
 const isFirefox = typeof navigator === 'object' && navigator.userAgent.includes('Firefox/');
 
 export const allStarsRegex = isFirefox
-	? /^(https?|wss?):[/][/][^/]+([/].*)?$/
-	: /^https?:[/][/][^/]+([/].*)?$/;
+	? /^(https?|wss?):[/][/][^/]+[/].*/
+	: /^https?:[/][/][^/]+[/].*/;
 export const allUrlsRegex = /^(https?|file|ftp):[/]+/;
 
 function getRawPatternRegex(matchPattern: string): string {


### PR DESCRIPTION
These regexes are only used for `test`-ing URLs, not for data extraction, so ending with `.+$` isn't useful:

https://github.com/fregante/webext-patterns/pull/9#discussion_r902875189

I'm holding this PR in the queue until a new breaking version is released (e.g. to improve the escaping of match patterns before turning them into regexes)