### PR TITLE
Changed doesUrlMatchPatterns and excludeDuplicatePatterns to accept lists properly

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -21,6 +21,8 @@ export function isValidPattern(matchPattern: string): boolean {
 }
 
 export function doesUrlMatchPatterns(url: string, ...matchPattern: string[]): boolean {
+	matchPattern = matchPattern.flat();
+
 	if (matchPattern.includes('<all_urls>') && allUrlsRegex.test(url)) {
 		return true;
 	}
@@ -126,7 +128,9 @@ export function globToRegex(...globs: readonly string[]): RegExp {
 	return new RegExp(globs.map(x => getRawGlobRegex(x)).join('|'));
 }
 
-export function excludeDuplicatePatterns(matchPatterns: readonly string[]): string[] {
+export function excludeDuplicatePatterns(...matchPatterns: readonly string[]): string[] {
+	matchPatterns = matchPatterns.flat();
+
 	if (matchPatterns.includes('<all_urls>')) {
 		return ['<all_urls>'];
 	}


### PR DESCRIPTION
Right now, the example for `doesUrlMatchPatterns` in the readme is incorrect:
```js
doesUrlMatchPatterns('https://google.com/', ['https://*.google.com/*', '*://example.com/*']);
```
This actually throws an error, because the function expects multiple string args, not a single list arg:
```js
export function doesUrlMatchPatterns(url: string, ...matchPattern: string[]): boolean {
```
This PR modifies both `doesUrlMatchPatterns` and `excludeDuplicatePatterns` to accept any combination of list args, multiple string args, or both. So you can do any of:
```js
doesUrlMatchPatterns('https://google.com/', ['https://*.google.com/*', '*://example.com/*']);
doesUrlMatchPatterns('https://google.com/', 'https://*.google.com/*', '*://example.com/*');
doesUrlMatchPatterns('https://google.com/', ['https://*.google.com/*'], '*://example.com/*');
```